### PR TITLE
[TRN-714] set useWordBoundary even if a false value is given

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -127,7 +127,7 @@ var marexandre;
      * @return {Array}                 [description]
      */
     Helper.prototype.cleanupOnWordBoundary = function(text, list, useWordBoundary) {
-      useWordBoundary = useWordBoundary || true;
+      useWordBoundary = !!useWordBoundary;
 
       var a = [], o, w, ww, wws;
 


### PR DESCRIPTION
- seemingly, original code doesn't have a way to set `false` into `useWordBounday`.
- to allow to set false, modified the statement to set a given value as a boolean.